### PR TITLE
Setup GitHub Pages site with Jekyll

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,23 @@
+name: Deploy Jekyll site to GitHub Pages
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  build-deploy:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      - name: Build Jekyll site
+        uses: jekyll/jekyll-action@v2
+
+      - name: Deploy to GitHub Pages
+        uses: peaceiris/actions-gh-pages@v3
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: _site

--- a/CNAME
+++ b/CNAME
@@ -1,0 +1,1 @@
+slopeintel.com

--- a/_config.yml
+++ b/_config.yml
@@ -1,0 +1,3 @@
+title: Slope Intel
+baseurl: ""
+url: "https://slopeintel.com"

--- a/index.md
+++ b/index.md
@@ -1,0 +1,1 @@
+coming soon


### PR DESCRIPTION
Set up a GitHub Pages site for the repository to serve a landing page with the text "coming soon" at slopeintel.com.

* **Landing Page**
  - Add `index.md` with the text "coming soon".

* **Jekyll Configuration**
  - Add `_config.yml` with the title "Slope Intel", baseurl as an empty string, and url set to "https://slopeintel.com".

* **GitHub Actions Workflow**
  - Add `.github/workflows/deploy.yml` to deploy the site using GitHub Actions.
  - Use `actions/checkout@v2` to check out the repository.
  - Use `jekyll/jekyll-action@v2` to build the site.
  - Use `peaceiris/actions-gh-pages@v3` to deploy the site to GitHub Pages.

* **Custom Domain**
  - Add `CNAME` file with the text "slopeintel.com".

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/slope-intel/website/pull/2?shareId=69ee02a3-aee5-4ae1-85ce-447b903bcc5a).